### PR TITLE
Restructure API handler so that it does not always email the user

### DIFF
--- a/backend/app/api.js
+++ b/backend/app/api.js
@@ -424,15 +424,21 @@ handlers.signUp = async function (info, req, res) {
       req.body.token,
   };
 
-  transporter.sendMail(mail, (err, data) => {
-    if (err) {
-      console.log(err);
+  database.createUser(req, (message) => {
+    if (message === 'User Created') {
+      transporter.sendMail(mail, (err, data) => {
+        if (err) {
+          console.log(err);
+          res.json(err);
+        } else {
+          console.log("Sent!");
+          res.json(message);
+        }
+      });
     } else {
-      console.log("Sent!");
-    }
+      res.json(message);
+    };
   });
-
-  database.createUser(req, (message) => res.json(message));
 };
 
 /*


### PR DESCRIPTION
When a user is signing up, even when they make a mistake they would still get an email verification. This pull request restructures the createUser handler so that it only sends an email when the user has successfully signed up.