### PR TITLE
Fixes constant-value drag bug by making circles' radius 0 when tabs are closed.

### DIFF
--- a/frontend/src/workspace/menu/MakeFunction2.js
+++ b/frontend/src/workspace/menu/MakeFunction2.js
@@ -53,6 +53,7 @@ import gui from "../globals/mistgui-globals";
 import { Spring, animated } from "react-spring/renderprops-konva";
 import { globalContext } from "../globals/global-context.js";
 import { fontContext} from '../globals/globals-fonts';
+import { Menu2 } from "../menu/Menu2.js";
 import globals from "../globals/globals";
 
 // +----------------------------+
@@ -69,6 +70,7 @@ function FuncGroup(props) {
   const description = "Testing Description"
   const fonts = useContext(fontContext);
   const [isHovered, setIsHovered] = useState(false);
+  const [visible, setVisible] = useState(false);
   // const tips = props.descript + "\n" + props.usage;
   useEffect(() => {
     //console.log("props:"+props);
@@ -126,8 +128,10 @@ function FuncGroup(props) {
         return pos;
       }}
       onMouseOver={function (props) {
+        //if (props.tabs.functionsOpen) {
         setIsHovered(true);
       }}
+    //}
       onMouseLeave={function (props) {
         setIsHovered(false);
       }}
@@ -136,26 +140,22 @@ function FuncGroup(props) {
       <Circle
         x={global.functionWidth}
         y={global.functionWidth/2}
-        opacity={props.tabs.functionsOpen? 
-          funName==="rgb" ? 0:1
-          : 0
-        }
-        Radius={global.valueWidth/10}
+        opacity={funName==="rgb" ? 0:1}
+        Radius={props.tabs.functionsOpen ? global.valueWidth/10 : 0} // if functions is not open, circles have radius of 0, therefore hiding them
         fill={"#B3B3B3"}
       />
       <Group>
         <Circle
           x={0}
           y={global.functionWidth/5}
-          opacity={props.tabs.functionsOpen? 1:0}
-          Radius={global.valueWidth/12}
+          // opacity={props.tabs.functionsOpen? 1:0}
+          Radius={props.tabs.functionsOpen ? global.valueWidth/12 : 0} // if functions is not open, circles have radius of 0, therefore hiding them
           fill={ funName === "rgb"? "red" : "#B3B3B3"}
         />
         <Circle
           x={0}
           y={global.functionWidth*2/5}
-          opacity={
-            props.tabs.functionsOpen? 
+          opacity={ 
               funName==="square" ||
               funName==="negate" ||
               funName==="sine" ||
@@ -163,27 +163,24 @@ function FuncGroup(props) {
               funName==="absolute" ||
               funName==="sign"
               ?
-                0 : 1
-              : 0
+                0 : 1 
           }
-          Radius={global.valueWidth/12}
+          Radius={props.tabs.functionsOpen ? global.valueWidth/12 : 0} // if functions is not open, circles have radius of 0, therefore hiding them
           fill={ funName === "rgb"? "green" : "#B3B3B3"}
         />
         <Circle
           x={0}
           y={global.functionWidth*3/5}
-          opacity={
-            props.tabs.functionsOpen? 
+          opacity={ 
               funName==="mistif" || funName==="rgb" 
                 ? 1 : 
                 funName === "add" ||
                 funName === "multiply" ||
                 funName === "average" ||
                 funName === "wrapsum" ?
-                .5 : 0
-              : 0
+                .5 : 0 
           }
-          Radius={global.valueWidth/12}
+          Radius={props.tabs.functionsOpen ? global.valueWidth/12 : 0} // if functions is not open, circles have radius of 0, therefore hiding them
           fill={ funName === "rgb"? "blue" : "#B3B3B3"}
         />
       </Group>

--- a/frontend/src/workspace/menu/MakeValue2.js
+++ b/frontend/src/workspace/menu/MakeValue2.js
@@ -131,8 +131,7 @@ function ValGroup(props) {
       <Circle
         y={global.valueWidth/2}
         x={global.valueWidth*.95}
-        opacity={props.tabs.valuesOpen? 1:0}
-        Radius={global.valueWidth/10}
+        Radius={props.tabs.valuesOpen ? global.valueWidth/10 : 0} // if values is not open, circles have radius of 0, therefore hiding them
         fill={"#B3B3B3"}
       />
       <Spring


### PR DESCRIPTION
The problem was that the nodes could be dragged onto the workspace by invisible (opacity=0) circles even when the function and value tabs were closed. 

We left the opacity the same no matter whether the tabs are open or closed (the remaining opacity controllers are for aesthetic purposes). To fix the issue, we made the circles have a radius of 0 when their tabs are closed, meaning they cannot be activated or dragged.